### PR TITLE
feat!: re-write websockets

### DIFF
--- a/backend/cmd/api/servers/servers.go
+++ b/backend/cmd/api/servers/servers.go
@@ -22,7 +22,7 @@ type CreateServerRequest struct {
 
 type Channel struct {
 	ID        int64     `db:"id" json:"id"`
-	ServerID  int64     `db:"server_id" json:"-"`
+	ServerID  int64     `db:"server_id" json:"server_id"`
 	Name      string    `db:"name" json:"name"`
 	Type      string    `db:"type" json:"type"`
 	CreatedAt time.Time `db:"created_at" json:"created_at"`

--- a/backend/migrations/001_init.sql
+++ b/backend/migrations/001_init.sql
@@ -15,7 +15,7 @@ CREATE TABLE servers (
 
 CREATE TABLE channels (
     id SERIAL PRIMARY KEY,
-    server_id INT REFERENCES servers(id),
+    server_id INT REFERENCES servers(id) ON DELETE CASCADE,
     name VARCHAR(50) NOT NULL,
     type VARCHAR(20) NOT NULL, -- 'text' or 'voice'
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/frontend/src/contexts/WebSocketContext.js
+++ b/frontend/src/contexts/WebSocketContext.js
@@ -1,0 +1,32 @@
+// WebSocketContext.js
+import React, { createContext, useContext, useEffect, useRef } from 'react';
+import ReconnectingWebSocket from 'reconnecting-websocket';
+
+const WebSocketContext = createContext(null);
+
+export const WebSocketProvider = ({ children }) => {
+  const token = localStorage.getItem('token');
+  const wsRef = useRef(null);
+
+  useEffect(() => {
+    if (!token) return;
+
+    const socketUrl = `ws://localhost:8080/ws?token=${token}`;
+    const ws = new ReconnectingWebSocket(socketUrl);
+    wsRef.current = ws;
+
+    ws.addEventListener('open', () => console.log('WebSocket connected'));
+    ws.addEventListener('close', () => console.log('WebSocket disconnected'));
+    ws.addEventListener('error', (err) => console.error('WebSocket error:', err));
+
+    return () => ws.close();
+  }, [token]);
+
+  return (
+    <WebSocketContext.Provider value={wsRef}>
+      {children}
+    </WebSocketContext.Provider>
+  );
+};
+
+export const useWebSocket = () => useContext(WebSocketContext);

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import { getServers } from '../api/servers/servers';
 import ServersSidebar from '../components/ServersSidebar';
 import ChannelsSidebar from '../components/ChannelsSidebar';
 import Chat from '../components/chat/Chat';
+import { WebSocketProvider } from '../contexts/WebSocketContext';
 
 const Dashboard = () => {
   const [servers, setServers] = useState([]);
@@ -26,33 +27,35 @@ const Dashboard = () => {
   }, []);
 
   return (
-    <div
-      className="flex flex-grow"
-      style={{ height: 'calc(100vh - 64px)' }}
-    >
-      <ServersSidebar
-        servers={servers}
-        selectedServerId={selectedServer?.id}
-        onSelectServer={(server) => {
-          setSelectedServer(server);
-          setSelectedChannel(server.channels[0]);
-        }}
-      />
-      <ChannelsSidebar
-        channels={selectedServer?.channels || []}
-        selectedChannelId={selectedChannel?.id}
-        onSelectChannel={setSelectedChannel}
-      />
-      <div className="flex-grow flex flex-col">
-        {selectedChannel ? (
-          <Chat channel={selectedChannel} key={selectedChannel?.id}/>
-        ) : (
-          <div className="flex flex-grow items-center justify-center text-gray-500">
-            Select a channel to start chatting
-          </div>
-        )}
+    <WebSocketProvider>
+      <div
+        className="flex flex-grow"
+        style={{ height: 'calc(100vh - 64px)' }}
+      >
+        <ServersSidebar
+          servers={servers}
+          selectedServerId={selectedServer?.id}
+          onSelectServer={(server) => {
+            setSelectedServer(server);
+            setSelectedChannel(server.channels[0]);
+          }}
+        />
+        <ChannelsSidebar
+          channels={selectedServer?.channels || []}
+          selectedChannelId={selectedChannel?.id}
+          onSelectChannel={setSelectedChannel}
+        />
+        <div className="flex-grow flex flex-col">
+          {selectedChannel ? (
+            <Chat channel={selectedChannel} key={selectedChannel?.id}/>
+          ) : (
+            <div className="flex flex-grow items-center justify-center text-gray-500">
+              Select a channel to start chatting
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </WebSocketProvider>
   );
 };
 


### PR DESCRIPTION
Before this commit, connections were done per channel. This is not so efficient.

After this commit, connections are done per user, so each user has one connection only. We store which servers the user is subscribed to,
and when this user sends a message to some server, we broadcast the message to all connections that has user subscribed to this server.